### PR TITLE
fix: prevent non exisiting dungeons from being added to `dungeonSort`

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -1,5 +1,5 @@
 local TOCNAME,GBB=...
-
+local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 local function getSeasonalDungeons()
     local events = {}
 
@@ -784,6 +784,18 @@ function GBB.GetDungeonSort()
 		end
     end
 
+	if isClassicEra then 
+		-- hack to remove dungeons from classic ui
+		GBB.WotlkDungeonNames = {}
+		GBB.TbcDungeonNames = {}
+		-- replace "NAX" with "NAXX" for the classic era
+		-- (this is to use the appropriate tags)
+		for i, key in ipairs(GBB.VanillDungeonNames) do
+			if key == "NAX" then
+				GBB.VanillDungeonNames[i] = "NAXX"
+			end
+		end
+	end
 	local dungeonOrder = { GBB.VanillDungeonNames, GBB.TbcDungeonNames, GBB.WotlkDungeonNames, GBB.PvpNames, GBB.Misc, GBB.DebugNames}
 
 	-- Why does Lua not having a fucking size function


### PR DESCRIPTION
Because non classic dungeons are added to this table, other options which iterate this table might cause bugs.

- fixes a bug where `GBB.UpdateList` would create header for invalid (for client) dungeons when the  `GBB.DB.EnableShowOnly` was enabled