### PR TITLE
CI: add BW packager for alpha builds to workflows

### DIFF
--- a/.github/workflows/release_alpha.yml
+++ b/.github/workflows/release_alpha.yml
@@ -1,0 +1,38 @@
+name: Package and release (cataclysm alpha)
+# This workflow automatically creates an alpha release when it runs on push to main, as there is no tag information available.
+
+on:
+  push:
+    branches:
+      - working-trunk
+  
+env:
+  CF_API_KEY: ${{ secrets.CF_API_KEY }}
+
+# a workflow is built up as jobs, and within these jobs are steps
+jobs:
+
+  # "release" is a job, you can name it anything you want
+  release:
+
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  # "GITHUB_TOKEN" is a secret always provided to the workflow
+                                                 # for your own token, the name cannot start with "GITHUB_"
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
+    steps:
+
+      # we first have to clone the AddOn project, this is a required step
+      - name: Clone project
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # gets git history for changelogs
+
+      # once cloned, we just run the GitHub Action for the packager project
+      - name: Package and release
+        uses: BigWigsMods/packager@v2.2.0
+        with:
+          args: -g cata -n "{package-name}-{game-type}-{relese-type}-{project-abbreviated-hash}"

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,4 @@
+package-as: LFGBulletinBoard
+
+move-folders:
+    LFGBulletinBoard/LFGBulletinBoard: LFGBulletinBoard

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -6,6 +6,8 @@
 ## DefaultState: enabled
 ## SavedVariables: GroupBulletinBoardDB
 ## SavedVariablesPerCharacter: GroupBulletinBoardDBChar
+## X-Curse-Project-ID: 484920
+
 LibGPIOptions.lua
 LibGPIMinimapButton.lua
 LibGPIToolBox.lua


### PR DESCRIPTION
Any un-tagged pushes to main will push a new alpha build to curseforge.

Currently only set for releasing to alpha and when pushing to my development branch `working-trunk`.

Packages will look something like 

"LFGBulletinBoard-cata-alpha-{hash}.zip"