### PR TITLE
CI: add multiple game versions to TOC

### DIFF
--- a/.github/workflows/release_alpha.yml
+++ b/.github/workflows/release_alpha.yml
@@ -33,6 +33,6 @@ jobs:
 
       # once cloned, we just run the GitHub Action for the packager project
       - name: Package and release
-        uses: BigWigsMods/packager@v2.2.0
+        uses: BigWigsMods/packager@v2.3.1
         with:
           args: -g cata -n "{package-name}-{game-type}-{relese-type}-{project-abbreviated-hash}"

--- a/LFGBulletinBoard/LFGBulletinBoard.toc
+++ b/LFGBulletinBoard/LFGBulletinBoard.toc
@@ -1,4 +1,4 @@
-## Interface: 11502
+## Interface: 11502, 40400
 ## Title: LFG Bulletin Board
 ## Notes: Sort LFG/LFM Messages
 ## Version: 3.24


### PR DESCRIPTION
This file should not be packaged directly anymore.

The packager will dynamically generate the proper toc file.

see https://github.com/marketplace/actions/wow-packager?version=v2.3.1#single-toc-file