### PR TITLE
dev: clarity updates to the `UpdateList` function

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -1,5 +1,5 @@
 local TOCNAME,GBB=...
-
+local isClassicEra = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
 local function getSeasonalDungeons()
     local events = {}
 
@@ -784,6 +784,18 @@ function GBB.GetDungeonSort()
 		end
     end
 
+	if isClassicEra then 
+		-- hack to remove dungeons from classic ui
+		GBB.WotlkDungeonNames = {}
+		GBB.TbcDungeonNames = {}
+		-- replace "NAX" with "NAXX" for the classic era
+		-- (this is to use the appropriate tags)
+		for i, key in ipairs(GBB.VanillDungeonNames) do
+			if key == "NAX" then
+				GBB.VanillDungeonNames[i] = "NAXX"
+			end
+		end
+	end
 	local dungeonOrder = { GBB.VanillDungeonNames, GBB.TbcDungeonNames, GBB.WotlkDungeonNames, GBB.PvpNames, GBB.Misc, GBB.DebugNames}
 
 	-- Why does Lua not having a fucking size function

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -112,7 +112,7 @@ local function CreateHeader(yy, dungeon)
 
 	-- Initialize this value now so we can (un)fold only existing entries later
 	-- while still allowing new headers to follow the HeadersStartFolded setting
-	if GBB.FoldedDungeons[dungeon]==nil then
+	if GBB.FoldedDungeons[dungeon] == nil then
 		GBB.FoldedDungeons[dungeon]=GBB.DB.HeadersStartFolded
 	end
 
@@ -480,21 +480,10 @@ function GBB.UpdateList()
 				-- and dungeons have already been filtered/combined at this point
 				-- create header (if needed)
 				if not existingHeaders[requestDungeon] then
-					
-					-- retaining old behvaiour of adding space for missing requests
-					-- once weve moved on to the next header's category/dungeon in `RequestList`
-					if GBB.DB.EnableShowOnly -- this behaviour only occured with this option enabled
-						and lastCategory and (requestDungeon ~= lastCategory) 
-						and not GBB.FoldedDungeons[lastCategory] -- dont add space to folded categories
-					then
-						local reserved = baseItemHeight*(GBB.DB.ShowOnlyNb - itemsInCategory)
-						scrollHeight = scrollHeight + reserved
-					end
-
 					scrollHeight = CreateHeader(scrollHeight, requestDungeon)
-					lastCategory = requestDungeon
 					itemsInCategory = 0; -- reset count on new category
 				end
+				
 				-- add entry
 				if GBB.FoldedDungeons[requestDungeon] ~= true -- not folded
 					and (not GBB.DB.EnableShowOnly -- no limit
@@ -505,14 +494,6 @@ function GBB.UpdateList()
 					itemsInCategory = itemsInCategory + 1
 				end
 			end
-		end
-	end
-
-	if GBB.DB.EnableShowOnly then
-		-- add space for missing requests in the last category
-		if lastCategory and not GBB.FoldedDungeons[lastCategory] then
-			local reserved = baseItemHeight*(GBB.DB.ShowOnlyNb - itemsInCategory)
-			scrollHeight = scrollHeight + reserved
 		end
 	end
 

--- a/LFGBulletinBoard/RequestList.lua
+++ b/LFGBulletinBoard/RequestList.lua
@@ -476,48 +476,6 @@ function GBB.UpdateList()
 				count = count + 1
 				local requestDungeon = req.dungeon
 
-				-- previously having this option enabled would create a header.
-				-- for *all* filtered dungeons (even i not requests existed).
-				-- This is opposed to only creating headers for categories with existing requests.
-				-- Which is the default behaviour without this option enabled.
-				-- Bug or feature here it is reimplemented
-				-- The following conditional black could can removed safely if the behaviour is unwanted.
-				if GBB.DB.EnableShowOnly 
-					-- only run once, right before the first request is processed
-					and requestIdx == 1 
-				then
-					local firstRequestSortIdx = GBB.dungeonSort[requestDungeon]
-					if firstRequestSortIdx and firstRequestSortIdx > 1 then
-						-- note: a 0.5 step is used to work around DM2 and SM2 having fractional sort indexes in the dungeonSort table (See Dungeons.lua)
-						for dungeonSortIdx = 1, firstRequestSortIdx - 1, 0.5 do
-							local categoryDungeon = GBB.dungeonSort[dungeonSortIdx]
-							if categoryDungeon then
-								if GBB.DB.CombineSubDungeons 
-								-- ignore "DEADMINES" mapped entries
-								-- see GBB.dungeonSecondTags
-								and categoryDungeon ~= "DM"
-								then
-									local parent = subDungeonParentLookup[categoryDungeon]
-									if parent then
-										categoryDungeon = parent
-									end
-								end
-								if not existingHeaders[categoryDungeon] -- header not created
-								and (ownRequestDungeons[categoryDungeon] -- is own request
-									or GBB.FilterDungeon(categoryDungeon, req.IsHeroic, req.IsRaid))-- category is tracked in filter options
-
-								then
-									scrollHeight = CreateHeader(scrollHeight, categoryDungeon)
-									if not GBB.FoldedDungeons[categoryDungeon] then
-										-- add space for missing requests 
-										scrollHeight = scrollHeight + baseItemHeight*GBB.DB.ShowOnlyNb
-									end
-								end
-							end
-						end
-					end
-				end
-				
 				-- Since RequestList is already sorted in order of dungeons
 				-- and dungeons have already been filtered/combined at this point
 				-- create header (if needed)
@@ -556,9 +514,6 @@ function GBB.UpdateList()
 			local reserved = baseItemHeight*(GBB.DB.ShowOnlyNb - itemsInCategory)
 			scrollHeight = scrollHeight + reserved
 		end
-
-		-- Originally, this option also added all the other tracked dungeon headers
-		-- that functionality has been removed.
 	end
 
 	-- adds a window's woth of padding to the bottom of the scroll frame


### PR DESCRIPTION
dev: clarity updates to the `UpdateList` function

- this changes none of the functionality, but renames variable and moves conditional logic to be more readable for debugging purposes.

fix: prevent non exisiting dungeons from being added to `dungeonSort`

Because non classic dungeons are added to this table, other options which iterate this table might cause bugs.

- fixes a bug where `GBB.UpdateList` would create header for invalid (for client) dungeons when the  `GBB.DB.EnableShowOnly` was enabled

fix: `CombineSubDungeons` compatibility in `UpdateList` main loop

The older logic was very convoluted when the `EnableShowOnly` option was set.

 - fixes #232 where sub dungeon headers (SML/SMG/SMA/etc) were being shown even when combine sub-dungeons option was set.

behavior: avoid empty category headers with `ShowOnlyEnable`

Removes the creation of headers for dungeons/categories with no request whenever the `ShowOnlyEnable` option is set.

fix: categories only take up required space

- removes old intended behavior where space based on the `ShowOnlyNb` limit was created for all shown categories
- fixes bug no.4 in #232