### PR TITLE
minor: rename `GBB.VanillaDungeonNames` to `GBB.VanillaDungeonKeys`

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -760,7 +760,7 @@ end
 GBB.PvpSodNames = pvpNames
 
 -- used in Tags.lua for determining which tags are safe for game version
-GBB.VanillaDungeonNames = GBB.GetSortedDungeonKeys(
+GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 	GBB.Enum.Expansions.Classic,
 	{ GBB.Enum.DungeonType.Dungeon, GBB.Enum.DungeonType.Raid }
 );
@@ -791,9 +791,9 @@ function GBB.GetDungeonSort()
 		end
     end
 
-	local dungeonOrder = { GBB.VanillaDungeonNames, tbcDungeonNames, wotlkDungeonNames, pvpNames, GBB.Misc, debugNames}
+	local dungeonOrder = { GBB.VanillaDungeonKeys, tbcDungeonNames, wotlkDungeonNames, pvpNames, GBB.Misc, debugNames}
 
-	local vanillaDungeonSize = #GBB.VanillaDungeonNames
+	local vanillaDungeonSize = #GBB.VanillaDungeonKeys
 
 	local tbcDungeonSize = GetSize(tbcDungeonNames)
 

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -593,7 +593,7 @@ if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
 
 	-- Collect tags valid for vanilla
 	local validDungeons = {}
-	for _, key in ipairs(GBB.VanillaDungeonNames) do
+	for _, key in ipairs(GBB.VanillaDungeonKeys) do
 		validDungeons[key] = true
 	end
 	-- using PvPSodNames just coz it already only has the classic bgs


### PR DESCRIPTION
This is to better reflect the purpose of the table, and differentiate from
the `GBB.GetDungeonNames` function.