### PR TITLE
feat: more dungeon keys added for cataclsym data pipeline

### DIFF
--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -31,7 +31,14 @@ local function CheckBoxChar (Var,Init)
 	return GBB.Options.AddCheckBox(GBB.DBChar,Var,Init,GBB.L["CboxChar"..Var])
 end
 local function CheckBoxFilter (Dungeon,Init)
-	return GBB.Options.AddCheckBox(GBB.DBChar,"FilterDungeon".. Dungeon,Init,GBB.dungeonNames[Dungeon].." "..GBB.LevelRange(Dungeon,true))
+	local dungeonName = (GBB.GetDungeonInfo(Dungeon, true) or {}).name
+	return GBB.Options.AddCheckBox(
+		GBB.DBChar, "FilterDungeon".. Dungeon, 
+		Init, 
+		((GBB.dungeonNames[Dungeon] 
+			or dungeonName or "ERROR"
+		).." "..GBB.LevelRange(Dungeon,true))
+	)
 end
 local function CreateEditBoxNumber (Var,Init,width,width2)
 	return GBB.Options.AddEditBox(GBB.DB,Var,Init,GBB.L["Edit"..Var],width,width2,true)
@@ -46,8 +53,15 @@ local function CreateEditBoxDungeon(Dungeon,Init,width,width2)
 		GBB.DB.Custom[Dungeon]=GBB.DB["Custom_"..Dungeon]
 		GBB.DB["Custom_"..Dungeon]=nil
 	end
-	if GBB.dungeonNames[Dungeon] then
-		GBB.Options.AddEditBox(GBB.DB.Custom, Dungeon, Init, GBB.dungeonNames[Dungeon].." "..GBB.LevelRange(Dungeon,true), width, width2, false,nil, GBB.Tool.Combine(GBB.dungeonTagsLoc["enGB"][Dungeon]))
+	local dungeonName = (GBB.GetDungeonInfo(Dungeon, true) or {}).name
+	if GBB.dungeonNames[Dungeon] or dungeonName then
+		GBB.Options.AddEditBox(GBB.DB.Custom, Dungeon, Init, 
+			((GBB.dungeonNames[Dungeon] or 
+				dungeonName).." "..GBB.LevelRange(Dungeon,true)
+			),
+			width, width2, false, nil, 
+			GBB.Tool.Combine(GBB.dungeonTagsLoc["enGB"][Dungeon])
+		)
 	else
 		local txt=""
 		if Dungeon=="Search" then

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -14,13 +14,12 @@ local PROJECT_EXPANSION_ID = {
 	[WOW_PROJECT_CATACLYSM_CLASSIC or 0] = GBB.Enum.Expansions.Cataclysm,
 }
 local EXPANSION_PROJECT_ID = tInvert(PROJECT_EXPANSION_ID)
+
 local EXPANSION_FILTER_NAME = {
-	[GBB.Enum.Expansions.Classic] = 
-		GBB.locales[GetLocale()]["PanelFilter"] or EXPANSION_NAME0,
-	[GBB.Enum.Expansions.BurningCrusade] = 
-		GBB.locales[GetLocale()]["TBCPanelFilter"] or EXPANSION_NAME1,
-	[GBB.Enum.Expansions.Wrath] = EXPANSION_NAME2,
-	[GBB.Enum.Expansions.Cataclysm] = EXPANSION_NAME3,
+	[GBB.Enum.Expansions.Classic] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME0),
+	[GBB.Enum.Expansions.BurningCrusade] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME1),
+	[GBB.Enum.Expansions.Wrath] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME2),
+	[GBB.Enum.Expansions.Cataclysm] = SUBTITLE_FORMAT:format(FILTERS, EXPANSION_NAME3),
 }
 --Options
 -------------------------------------------------------------------------------------

--- a/LFGBulletinBoard/Options.lua
+++ b/LFGBulletinBoard/Options.lua
@@ -19,8 +19,7 @@ local EXPANSION_FILTER_NAME = {
 		GBB.locales[GetLocale()]["PanelFilter"] or EXPANSION_NAME0,
 	[GBB.Enum.Expansions.BurningCrusade] = 
 		GBB.locales[GetLocale()]["TBCPanelFilter"] or EXPANSION_NAME1,
-	[GBB.Enum.Expansions.Wrath] = 
-		GBB.locales[GetLocale()]["WotlkPanelFilter"] or EXPANSION_NAME2,
+	[GBB.Enum.Expansions.Wrath] = EXPANSION_NAME2,
 	[GBB.Enum.Expansions.Cataclysm] = EXPANSION_NAME3,
 }
 --Options
@@ -159,11 +158,7 @@ end
 local function GenerateExpansionPanel(expansionID)
 	GBB.Options.AddPanel(EXPANSION_FILTER_NAME[expansionID], false, true)
 	
-	-- hack to show misc filters on wotlk panel
-	local WOW_PROJECT_ID = isCata and WOW_PROJECT_WRATH_CLASSIC or WOW_PROJECT_ID;
-	
 	local isCurrentXpac = expansionID == PROJECT_EXPANSION_ID[WOW_PROJECT_ID];
-	local xOffset = 0
 	local filters = {} ---@type CheckButton[]
 	local dungeons = GBB.GetSortedDungeonKeys(
 		expansionID, GBB.Enum.DungeonType.Dungeon
@@ -175,14 +170,6 @@ local function GenerateExpansionPanel(expansionID)
 		expansionID, GBB.Enum.DungeonType.Battleground
 	);
 	
-	-- hack to show bgs on wotlk panel atm
-	-- Bg keys only exists for the latest expansion
-	if expansionID == GBB.Enum.Expansions.Wrath then
-		bgs = GBB.GetSortedDungeonKeys(
-			GBB.Enum.Expansions.Cataclysm, GBB.Enum.DungeonType.Battleground
-		);
-	end
-
 	-- Dungeons 		
 	GBB.Options.AddCategory(DUNGEONS)
 	GBB.Options.Indent(10)
@@ -372,24 +359,19 @@ function GBB.OptionsInit ()
 	GBB.Options.AddButton(RESET_POSITION,GBB.ResetWindow)
 	GBB.Options.AddSpace()
 	----------------------------------------------------------
-	-- Pre Cataclysm Filters
+	-- Expansion specific filters
 	----------------------------------------------------------
-	if not isClassicEra then
-		------------------------------
+	if not isClassicEra then 
+		--- Cata Filters
+		GenerateExpansionPanel(GBB.Enum.Expansions.Cataclysm)
 		--- Wrath Filters
-		------------------------------
 		GenerateExpansionPanel(GBB.Enum.Expansions.Wrath)
-		------------------------------
 		--- TBC Filters
-		------------------------------
 		GenerateExpansionPanel(GBB.Enum.Expansions.BurningCrusade)
 	end
-	
-	----------------------------------------------------------
 	-- Vanilla Filters
-	----------------------------------------------------------
 	GenerateExpansionPanel(GBB.Enum.Expansions.Classic)
-	
+		
 	----------------------------------------------------------
 	-- Tags
 	----------------------------------------------------------

--- a/LFGBulletinBoard/dungeons/cata.lua
+++ b/LFGBulletinBoard/dungeons/cata.lua
@@ -31,22 +31,22 @@ local DungeonType = {
 -- These same keys are used for identifying the preset tags/keywords for each dungeon. If a tags Key is missing from this table, the tags will not be registered.
 -- modifications here should be reflected in the `Tags.lua` file and vice versa.
 local LFGDungeonIDs = {
-	NULL = 358,	-- 10v10 Rated Battleground (RBG)
+	RBG = 358,	-- 10v10 Rated Battleground (RBG)
 	AQ20 = 160,	-- Ahn'Qiraj Ruins
 	AQ40 = 161,	-- Ahn'Qiraj Temple
 	ANK = 218,	-- Ahn'kahet: The Old Kingdom
 	CRYPTS = 149,	-- Auchenai Crypts
 	AZN = 204,	-- Azjol-Nerub
-	NULL = 328,	-- Baradin Hold
+	BH = 328,	-- Baradin Hold
 	BT = 196,	-- Black Temple
 	BFD = 10,   -- Blackfathom Deeps
-	NULL = 303,	-- Blackrock Caverns
+	BRC = 303,	-- Blackrock Caverns
 	
 	-- These get put into "BRD"
 	NULL = 30,  -- Blackrock Depths - Detention Block
 	NULL = 276,	-- Blackrock Depths - Upper City
 	
-	NULL = 313,	-- Blackwing Descent
+	BWD = 313,	-- Blackwing Descent
 	BWL = 50,   -- Blackwing Lair
 	BF = 137,	-- Blood Furnace
 	DM = 6,     -- Deadmines
@@ -55,25 +55,25 @@ local LFGDungeonIDs = {
 	DME = 34,	-- Dire Maul - East (Renamed in Cata)
 	DMN = 38,	-- Dire Maul - North (Renamed in Cata)
 	DMW = 36,	-- Dire Maul - West (Renamed in Cata)
-	NULL = 447,	-- Dragon Soul
+	-- DS = 447,	-- Dragon Soul
 	DTK = 214,	-- Drak'Tharon Keep
-	NULL = 435,	-- End Time
-	NULL = 417,	-- Fall of Deathwing
-	NULL = 361,	-- Firelands
+	-- END_TIME = 435,	-- End Time
+	NULL = 417,	-- Fall of Deathwing (LFR)
+	-- FL = 361,	-- Firelands
 	GNO = 14,   -- Gnomeregan
-	NULL = 304,	-- Grim Batol
+	GB = 304,	-- Grim Batol
 	GL = 177,	-- Gruul's Lair
 	GD = 216,	-- Gundrak
 	HOL = 207,	-- Halls of Lightning
-	NULL = 305,	-- Halls of Origination
+	HOO = 305,	-- Halls of Origination
 	HOR = 255,	-- Halls of Reflection
 	HOS = 208,	-- Halls of Stone
 	RAMPS = 136,-- Hellfire Ramparts
-	NULL = 439,	-- Hour of Twilight
+	-- HOT = 439,	-- Hour of Twilight
 	HYJAL = 195,-- Hyjal Past
 	ICC = 279,	-- Icecrown Citadel
 	KARA = 175,	-- Karazhan
-	NULL = 312,	-- Lost City of the Tol'vir
+	TOLVIR = 312,	-- Lost City of the Tol'vir
 	LBRS = 32,  -- Lower Blackrock Spire
 	MGT = 198,	-- Magisters' Terrace
 	MAG = 176,	-- Magtheridon's Lair
@@ -118,7 +118,7 @@ local LFGDungeonIDs = {
 	ST = 28,    -- Sunken Temple
 	EYE = 193,	-- Tempest Keep (The Eye)
 	ARC = 174,	-- The Arcatraz
-	NULL = 315,	-- The Bastion of Twilight
+	BOT2 = 315,	-- The Bastion of Twilight
 	BOT = 173,	-- The Botanica
 	COS = 209,	-- The Culling of Stratholme
 	OHB = 170,	-- The Escape From Durnholde (Old Hillsbrad Foothills)
@@ -128,13 +128,13 @@ local LFGDungeonIDs = {
 	NEX = 225,	-- The Nexus
 	OS = 224,	-- The Obsidian Sanctum
 	OCC = 206,	-- The Oculus
-	NULL = 416,	-- The Siege of Wyrmrest Temple
+	NULL = 416,	-- The Siege of Wyrmrest Temple (LFR)
 	SV = 147,	-- The Steamvault
-	NULL = 307,	-- The Stonecore
+	TSC = 307,	-- The Stonecore
 	SWP = 199,	-- The Sunwell
-	NULL = 311,	-- The Vortex Pinnacle
-	NULL = 317,	-- Throne of the Four Winds
-	NULL = 302,	-- Throne of the Tides
+	VP = 311,	-- The Vortex Pinnacle
+	TOFW = 317,	-- Throne of the Four Winds
+	TOTT = 302,	-- Throne of the Tides
 	CHAMP = 245,-- Trial of the Champion
 	TOTC = {
 		246,	-- Trial of the Crusader
@@ -156,15 +156,15 @@ local LFGDungeonIDs = {
 
 	-- Seasonal
 	BREW = 287,	-- Coren Direbrew (Brewfest)
-	NULL = 288,	-- The Crown Chemical Co. (Love is in the Air)
-	NULL = 286,	-- The Frost Lord Ahune (Midsummer)
+	LOVE = 288,	-- The Crown Chemical Co. (Love is in the Air)
+	SUMMER = 286,	-- The Frost Lord Ahune (Midsummer)
 	HOLLOW = 285,	-- The Headless Horseman (Hallow's End)
 
-	-- Cata prepatch bosses
-	EARTH_PORTAL = 297,	-- Crown Princess Theradras
-	FIRE_PORTAL = 296,	-- Grand Ambassador Flamelash
-	WATER_PORTAL = 298,	-- Kai'ju Gahz'rilla
-	AIR_PORTAL = 299,	-- Prince Sarsarun
+	-- Cata prepatch bosses (unused for cata rerelease)
+	-- EARTH_PORTAL = 297,	-- Crown Princess Theradras
+	-- FIRE_PORTAL = 296,	-- Grand Ambassador Flamelash
+	-- WATER_PORTAL = 298,	-- Kai'ju Gahz'rilla
+	-- AIR_PORTAL = 299,	-- Prince Sarsarun
 }
 local dungeonIDToKey = {}
 for key, dungeonID in pairs(LFGDungeonIDs) do
@@ -302,7 +302,7 @@ local infoOverrides = {
 	-- DMN = { minLevel = 42, maxLevel = 52 },
 	-- The pvp dungeons arent in th LFGDungeons table in the cata client atm. (except for RBG)
 	-- and the GetActivityInfoTable API is returning `0` for min/max level so we'll just hardcode it here.
-	ARENA = { minLevel = 10, maxLevel = effectiveMaxLevel },
+	ARENA = { minLevel = effectiveMaxLevel, maxLevel = effectiveMaxLevel },
 	WSG = { minLevel = 10, maxLevel = effectiveMaxLevel },
 	AB = { minLevel = 10, maxLevel = effectiveMaxLevel },
 	EOTS = { minLevel = 35, maxLevel = effectiveMaxLevel },


### PR DESCRIPTION
- `RBG`: 10v10 Rated Battleground
- `BH`: Baradin Hold
- `BRC`: Blackrock Caverns
- `BWD`: Blackwing Descent
- `GB`: Grim Batol
- `HOO`: Halls of Origination
- `TOLVIR`: Lost City of the Tol'vir
- `BOT2`: The Bastion of Twilight
- `TSC`: The Stonecore
- `VP`: The Vortex Pinnacle
- `TOTT`: Throne of the Tides

**note**: These dungeons have no associated tags and will not be picked up in lfg messages yet.
This just adds them to the ui.