### PR TITLE
feat: add "Random Dungeon" category for cataclysm

### DIFF
--- a/LFGBulletinBoard/Dungeons.lua
+++ b/LFGBulletinBoard/Dungeons.lua
@@ -623,6 +623,8 @@ function GBB.GetDungeonNames()
 	for _, key in ipairs(dungeonKeys) do
 		DefaultEnGB[key] = GBB.GetDungeonInfo(key).name or DefaultEnGB[key]
 	end
+	DefaultEnGB["RDF"] = LFG_TYPE_RANDOM_DUNGEON
+
 	setmetatable(dungeonNames, {__index = DefaultEnGB})
 
 	dungeonNames["DEADMINES"]=dungeonNames["DM"]
@@ -687,7 +689,7 @@ local raidNames = GBB.GetSortedDungeonKeys(
 local miscCatergoriesLevels = {
 	["MISC"] =  {0,100}, ["TRAVEL"]={0,100}, ["INCUR"]={0,100},
 	["DEBUG"] = {0,100}, ["BAD"] =	{0,100}, ["TRADE"]=	{0,100},
-	["BLOOD"] = {0,100}, ["NIL"] = {0,100}
+	["BLOOD"] = {0,100}, ["NIL"] = {0,100}, ["RDF"] = {0, 100},
 }
 
 -- Needed because Lua sucks, Blizzard switch to Python please
@@ -738,7 +740,10 @@ GBB.VanillaDungeonKeys = GBB.GetSortedDungeonKeys(
 
 
 -- used in Tags.lua for determining which tags are safe for game version
-GBB.Misc = {"MISC", "TRADE", "TRAVEL", (isSoD and "INCUR" or nil)}
+GBB.Misc = {
+	(isCata and "RDF" or nil), "MISC", "TRADE", "TRAVEL",
+	(isSoD and "INCUR" or nil)
+}
 
 -- used to disable holiday specific filters when not in the correct date range
 -- in FixFilters of Options.lua

--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1011,6 +1011,10 @@ local otherTags = {
 	  zhTW = nil,
 	  zhCN = nil,
 	} or nil,
+	--- Random Dungeon Finder
+	RDF = not isClassicEra and {
+	  enGB = "rdf random dungeons spam heroics",
+	}
 }
 
 --- Secondary Dungeon Tags: related to identifying dungeon or activity name from a message.
@@ -1061,7 +1065,8 @@ end
 for locale, dungeonTags in pairs(GBB.dungeonTagsLoc) do
 	for dungeonKey, _ in pairs(dungeonTags) do
 		if not (validGameVersionKeys[dungeonKey] 
-			or GBB.dungeonSecondTags[dungeonKey])
+			or GBB.dungeonSecondTags[dungeonKey]
+			or otherTags[dungeonKey])
 		then
 			GBB.dungeonTagsLoc[locale][dungeonKey] = nil
 		end


### PR DESCRIPTION
- useful atm since ppl seem just be spamming the rdf tool
- disabled by default, users will have to check the filter in the cataclysm panel.
- only english tags added
![example](https://i.imgur.com/39PnGYk.png)