### PR TITLE
ci: update manual changelog location for `.pkgmeta`

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -4,4 +4,4 @@ move-folders:
     LFGBulletinBoard/LFGBulletinBoard: LFGBulletinBoard
 
 manual-changelog:
-    LFGBulletinBoard/changelog.txt
+    changelog.txt


### PR DESCRIPTION
I guess its expecting the resulting filepath for the changelog after packaging.