### PR TITLE
hotfix: `nil` out `RDF` tags when not in use

### DIFF
--- a/LFGBulletinBoard/Tags.lua
+++ b/LFGBulletinBoard/Tags.lua
@@ -1014,7 +1014,7 @@ local otherTags = {
 	--- Random Dungeon Finder
 	RDF = not isClassicEra and {
 	  enGB = "rdf random dungeons spam heroics",
-	}
+	} or nil
 }
 
 --- Secondary Dungeon Tags: related to identifying dungeon or activity name from a message.


### PR DESCRIPTION
- fixes as bug that would crash classic era clients.