### PR TITLE
fix: corrupt table data for accent stripping function in `LibGPIToolBox`

### DIFF
--- a/LFGBulletinBoard/LibGPIToolBox.lua
+++ b/LFGBulletinBoard/LibGPIToolBox.lua
@@ -1,4 +1,6 @@
-local TOCNAME,Addon = ...
+local TOCNAME,
+	---@class Addon_Tool	
+	Addon = ...;
 Addon.Tool=Addon.Tool or {}
 local Tool=Addon.Tool
 
@@ -64,20 +66,19 @@ for eng,name in pairs(LOCALIZED_CLASS_NAMES_FEMALE) do
 	Tool.NameToClass[name]=eng
 end
 
-local _tableAccents = {
-    ["�"] = "A", ["�"] = "A", ["�"] = "A", ["�"] = "A", ["�"] = "Ae", ["�"] = "A",
-	["�"] = "AE", ["�"] = "C", ["�"] = "E", ["�"] = "E", ["�"] = "E", ["�"] = "E", 
-	["�"] = "I", ["�"] = "I", ["�"] = "I", ["�"] = "I", ["�"] = "D", ["�"] = "N", 
-	["�"] = "O", ["�"] = "O", ["�"] = "O", ["�"] = "O", ["�"] = "Oe", ["�"] = "O", 
-	["�"] = "U", ["�"] = "U", ["�"] = "U", ["�"] = "Ue", ["�"] = "Y", ["�"] = "P", 
-	["�"] = "s", ["�"] = "a", ["�"] = "a", ["�"] = "a", ["�"] = "a", ["�"] = "ae", 
-	["�"] = "a", ["�"] = "ae", ["�"] = "c", ["�"] = "e", ["�"] = "e", ["�"] = "e", 
-	["�"] = "e", ["�"] = "i", ["�"] = "i", ["�"] = "i", ["�"] = "i", ["�"] = "eth", 
-	["�"] = "n", ["�"] = "o", ["�"] = "o", ["�"] = "o", ["�"] = "o", ["�"] = "oe", 
-	["�"] = "o", ["�"] = "u", ["�"] = "u", ["�"] = "u", ["�"] = "ue", ["�"] = "y", 
-	["�"] = "p", ["�"] = "y", ["�"] = "ss",
-	}
-
+local transliterations = {
+    ["À"] = "A", ["Á"] = "A", ["Â"] = "A", ["Ã"] = "A", ["Ä"] = "Ae", ["Å"] = "A",
+	["Æ"] = "AE", ["Ç"] = "C", ["È"] = "E", ["É"] = "E", ["Ê"] = "E", ["Ë"] = "E", 
+	["Ì"] = "I", ["Í"] = "I", ["Î"] = "I", ["Ï"] = "I", ["Ð"] = "D", ["Ñ"] = "N", 
+	["Ò"] = "O", ["Ó"] = "O", ["Ô"] = "O", ["Õ"] = "O", ["Ö"] = "Oe", ["Ø"] = "O", 
+	["Ù"] = "U", ["Ú"] = "U", ["Û"] = "U", ["Ü"] = "Ue", ["Ý"] = "Y", ["Þ"] = "P", 
+	["ẞ"] = "s", ["à"] = "a", ["á"] = "a", ["â"] = "a", ["ã"] = "a", ["ä"] = "ae", 
+	["å"] = "a", ["æ"] = "ae", ["ç"] = "c", ["è"] = "e", ["é"] = "e", ["ê"] = "e", 
+	["ë"] = "e", ["ì"] = "i", ["í"] = "i", ["î"] = "i", ["ï"] = "i", ["ð"] = "eth", 
+	["ñ"] = "n", ["ò"] = "o", ["ó"] = "o", ["ô"] = "o", ["õ"] = "o", ["ö"] = "oe", 
+	["ø"] = "o", ["ù"] = "u", ["ú"] = "u", ["û"] = "u", ["ü"] = "ue", ["ý"] = "y", 
+	["þ"] = "p", ["ÿ"] = "y", ["ß"] = "ss",
+}
 -- Hyperlink
 
 local function EnterHyperlink(self,link,text)
@@ -266,8 +267,11 @@ function Tool.iMerge(t1,...)
 	return t1
 end
 
+---Replaces special characters and characters with accents from a given string.
+---@param str string
+---@return string, number
 function Tool.stripChars(str)
-	return string.gsub(str,"[%z\1-\127\194-\244][\128-\191]*", _tableAccents)
+	return string.gsub(str,"[%z\1-\127\194-\244][\128-\191]*", transliterations)
 end
 
 function Tool.CreatePattern(pattern,maximize)		


### PR DESCRIPTION
The table keys themselves should now appear as expected when viewed and saved with utf-8.

- This should improve dungeon detection in non-English messages (granted they use a Latin character set*)